### PR TITLE
Improve EQC tests and fix bug in histogram code

### DIFF
--- a/src/basho_stats_histogram.erl
+++ b/src/basho_stats_histogram.erl
@@ -28,6 +28,10 @@
          observations/1,
          summary_stats/1]).
 
+-ifdef(EQC).
+-export([prop_count/0, prop_quantile/0]).
+-endif.
+
 -include("stats.hrl").
 
 -record(hist, { n = 0,
@@ -135,10 +139,10 @@ which_bin(Value, Hist) ->
     if
         Value > Upper ->
             erlang:min(Bin + 1, Hist#hist.capacity - 1);
-
         Value =< Lower ->
             erlang:max(Bin - 1, 0);
-                    
+        Value == Hist#hist.max ->
+            Hist#hist.capacity-1;
         true ->
             Bin
     end.
@@ -180,24 +184,45 @@ simple_test() ->
 
 -ifdef(EQC).
 
+
 qc_count_check(Min, Max, Bins, Xs) ->
     LCounts = counts(update_all(Xs, new(Min, Max, Bins))),
-    RCounts = basho_stats_utils:r_run(Xs, ?FMT("hist(x, seq(~w,~w,length.out=~w), plot=FALSE)$counts",
+    RCounts = basho_stats_utils:r_run(Xs,
+        ?FMT("hist(x, seq(~w,~w,length.out=~w), plot=FALSE)$counts",
                                          [Min, Max, Bins+1])),
-    LCounts == RCounts.
+    case LCounts == RCounts of
+        true ->
+            true;
+        _ ->
+            io:format("LCounts ~p, RCounts ~p~n", [LCounts, RCounts]),
+            false
+    end.
 
 
+prop_count() ->
+    ?FORALL({Min, Bins, Xlen}, {choose(0, 99), choose(2, 20), choose(2, 100)},
+        ?LET(Max, choose(Min+1, 100),
+            ?LET(Xs, vector(Xlen, choose(Min, Max)),
+                ?WHENFAIL(
+                    begin
+                            io:format("Min ~p, Max ~p, Bins ~p, Xs ~w~n",
+                                [Min, Max, Bins, Xs]),
+                            Command = ?FMT("hist(x, seq(~w,~w,length.out=~w), plot=FALSE)$counts",
+                                [Min, Max, Bins+1]),
+                            InputStr = [integer_to_list(I) || I <- Xs],
+                            io:format(?FMT("x <- c(~s)\n", [string:join(InputStr, ",")])),
+                            io:format(?FMT("write(~s, ncolumns=1, file=stdout())\n", [Command]))
+                    end,
+                    qc_count_check(Min, Max, Bins, Xs))))).
 
 qc_count_test() ->
-    P = ?LET({Min, Bins, Xlen}, {choose(0, 99), choose(2, 20), choose(2, 100)},
-             ?LET(Max, choose(Min+1, 100),
-                  ?FORALL(Xs, vector(Xlen, choose(Min, Max)),
-                          qc_count_check(Min, Max, Bins, Xs)))),
-    true = eqc:quickcheck(P).
+    true = eqc:quickcheck(prop_count()).
 
 qc_quantile_check(Q, Min, Max, Bins, Xs) ->
-    Lq = quantile(Q * 0.01, update_all(Xs, new(Min, Max, Bins))),
-    [Rq] = basho_stats_utils:r_run(Xs, ?FMT("quantile(x, ~4.2f)", [Q * 0.01])),
+    Hist = new(Min, Max, Bins),
+    LCounts = counts(update_all(Xs, Hist)),
+    Lq = quantile(Q * 0.01, update_all(Xs, Hist)),
+    [Rq] = basho_stats_utils:r_run(Xs, ?FMT("quantile(x, ~4.2f, type=4)", [Q * 0.01])),
     case abs(Lq - Rq) < 1 of
         true ->
             true;
@@ -205,24 +230,38 @@ qc_quantile_check(Q, Min, Max, Bins, Xs) ->
             ?debugMsg("----\n"),
             ?debugFmt("Q: ~p Min: ~p Max: ~p Bins: ~p\n", [Q, Min, Max, Bins]),
             ?debugFmt("Lq: ~p != Rq: ~p\n", [Lq, Rq]),
-            ?debugFmt("Xs: ~p\n", [Xs]),
+            ?debugFmt("Xs: ~w\n", [Xs]),
             false
     end.
 
-qc_quantile_test() ->
+prop_quantile() ->
     %% Loosey-goosey checking of the quantile estimation against R's more precise method.
     %%
     %% To ensure a minimal level of accuracy, we ensure that we have between 50-200 bins
     %% and between 100-500 data points.
     %%
     %% TODO: Need to nail down the exact error bounds
-    P = ?LET({Min, Bins, Xlen, Q}, {choose(1, 99), choose(50, 200), choose(100, 500),
+    %%
+    %% XXX since we try to generate the quantile from the histogram, not the
+    %% original data, our results and Rs don't always agree and this means the
+    %% test will occasionally fail. There's not an easy way to fix this.
+    ?FORALL({Min, Bins, Xlen, Q}, {choose(1, 99), choose(50, 200), choose(100, 500),
                                     choose(0,100)},
              ?LET(Max, choose(Min+1, 100),
-                  ?FORALL(Xs, vector(Xlen, choose(Min, Max)),
-                          qc_quantile_check(Q, Min, Max, Bins, Xs)))),
-    true = eqc:quickcheck(P).
+                  ?LET(Xs, vector(Xlen, choose(Min, Max)),
+                      ?WHENFAIL(
+                          begin
+                                  io:format("Min ~p, Max ~p, Bins ~p, Q ~p, Xs ~w~n",
+                                      [Min, Max, Bins, Q, Xs]),
+                                  Command = ?FMT("quantile(x, ~4.2f, type=4)", [Q * 0.01]),
+                                  InputStr = [integer_to_list(I) || I <- Xs],
+                                  io:format(?FMT("x <- c(~s)\n", [string:join(InputStr, ",")])),
+                                  io:format(?FMT("write(~s, ncolumns=1, file=stdout())\n", [Command]))
+                          end,
+                          qc_quantile_check(Q, Min, Max, Bins, Xs))))).
 
+qc_quantile_test() ->
+    true = eqc:quickcheck(prop_quantile()).
 
--endif.            
+-endif.
 -endif. 

--- a/src/basho_stats_sample.erl
+++ b/src/basho_stats_sample.erl
@@ -30,6 +30,10 @@
 
 -include("stats.hrl").
 
+-ifdef(EQC).
+-export([prop_main/0]).
+-endif.
+
 -record(state, { n = 0,
                  min = 'NaN',
                  max = 'NaN',
@@ -130,12 +134,14 @@ lists_equal([V1 | R1], [V2 | R2]) ->
             false
     end.
 
+prop_main() ->
+    ?FORALL(Xlen, choose(2, 100),
+        ?LET(Xs, vector(Xlen, int()),
+            lists_equal(basho_stats_utils:r_run(Xs,"c(min(x), mean(x), max(x), var(x), sd(x))"),
+                tuple_to_list(summary(update_all(Xs, new())))))).
+
 qc_test() ->
-    Prop = ?LET(Xlen, choose(2, 100),
-                ?FORALL(Xs, vector(Xlen, int()),
-                        lists_equal(basho_stats_utils:r_run(Xs,"c(min(x), mean(x), max(x), var(x), sd(x))"),
-                                    tuple_to_list(summary(update_all(Xs, new())))))),
-    true = eqc:quickcheck(Prop).
+    true = eqc:quickcheck(prop_main()).
 
 -endif.
 


### PR DESCRIPTION
The histogram code was wrong in the case where a value was the same as
the maximum allowed. Before the fix, it'd get put in in the 'Bins + 1'
bin, instead of the final bin actually used in the histogram.

The EQC tests have also been significantly improved so that error
messages from R are captured, shrinking works correctly and the property
can be tested from quickcheck directly without involving eunit.
