### PR TITLE
Fix/otp 18 warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+include tools.mk
 
-all:
-	./rebar compile eunit
+all: compile test
+
+compile:
+	@./rebar compile
 
 clean:
 	./rebar clean

--- a/src/basho_stats_utils.erl
+++ b/src/basho_stats_utils.erl
@@ -61,9 +61,9 @@ r_port() ->
     try port_command(Port, "write('', file=stdout())\n") of
         _ ->
             receive
-                {Port, {data, {eol, []}}} ->
+                {_Port, {data, {eol, []}}} ->
                     {ok, Port};
-                {Port, {data, {eol, Other}}} ->
+                {_Port, {data, {eol, Other}}} ->
                     erlang:erase(r_port),
                     {error, Other}
             end

--- a/tools.mk
+++ b/tools.mk
@@ -28,11 +28,11 @@ endif
 
 dialyzer: ${PLT} ${LOCAL_PLT}
 	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
-ifeq (,$(wildcard $(LOCAL_PLT)))
-	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin
-else
-	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin
-endif
+	@if [ -f $(LOCAL_PLT) ]; then \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin; \
+	else \
+		dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin; \
+	fi
 
 cleanplt:
 	@echo 

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,45 @@
+test: compile
+	./rebar eunit skip_deps=true
+
+docs:
+	./rebar doc skip_deps=true
+
+PLT ?= $(HOME)/.riak_combo_dialyzer_plt
+LOCAL_PLT = .local_dialyzer_plt
+DIALYZER_FLAGS ?= -Wunmatched_returns
+
+${PLT}: compile
+ifneq (,$(wildcard $(PLT)))
+	dialyzer --check_plt --plt $(PLT) --apps $(DIALYZER_APPS) && \
+		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(DIALYZER_APPS) ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(PLT) --apps $(DIALYZER_APPS); test $$? -ne 1
+endif
+
+${LOCAL_PLT}: compile
+ifneq (,$(wildcard deps/*))
+ifneq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
+		dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+else
+	dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1
+endif
+endif
+
+dialyzer: ${PLT} ${LOCAL_PLT}
+	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
+ifeq (,$(wildcard $(LOCAL_PLT)))
+	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) -c ebin
+else
+	dialyzer $(DIALYZER_FLAGS) --plts $(PLT) $(LOCAL_PLT) -c ebin
+endif
+
+cleanplt:
+	@echo 
+	@echo "Are you sure?  It takes several minutes to re-build."
+	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
+	@echo 
+	sleep 5
+	rm $(PLT)
+	rm $(LOCAL_PLT)
+


### PR DESCRIPTION
Merge other commits accumulated on the master branch and fix compilation warnings with OTP-18+:

```
    src/basho_stats_utils.erl:64: Warning: variable 'Port' exported from 'case' (line 50)
    src/basho_stats_utils.erl:66: Warning: variable 'Port' exported from 'case' (line 50)
```