### PR TITLE
Use the basho fork for all dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-    {rand_compat, "1.1", {git, "https://github.com/tuncer/erlang-rand-compat.git", {tag, "v1.1"}}}
+    {rand_compat, "1.1", {git, "https://github.com/basho/erlang-rand-compat.git", {tag, "v1.1"}}}
 ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
As per standard practice, we are trying to always use our own clones of third-party repos for dependencies. This will improve build repeatability, and help us guard against situations where history is rewritten or repositories are deleted.